### PR TITLE
Single state for component graph

### DIFF
--- a/lib/component/index.js
+++ b/lib/component/index.js
@@ -27,6 +27,12 @@ module.exports = component;
 function component(spec) {
   spec = spec || {};
 
+  // Alow just a render function.
+
+  if (typeof spec === 'function') {
+    spec = { render: spec };
+  }
+
   /**
    * A component is a stateful virtual dom element.
    *

--- a/lib/renderer/component.js
+++ b/lib/renderer/component.js
@@ -26,12 +26,15 @@ module.exports = ComponentRenderer;
  *
  * @param {Function} Component
  * @param {Object} props
+ * @param {String} path The path to this component from the root
  */
 
-function ComponentRenderer(Component, props) {
+function ComponentRenderer(Component, props, path, parentState) {
+  this.path = path;
+  this.parentState = parentState;
   this.instance = new Component();
   this.props = props || {};
-  this.state = this.instance.initialState();
+  this.state = parentState[this.path] = parentState[this.path] || this.instance.initialState();
   this.children = {};
   this.interactions = new Interactions(this);
   this.previous = null;
@@ -173,6 +176,9 @@ ComponentRenderer.prototype.update = function(force){
   this.state = assign({}, this.state, this.instance._pendingState);
   this.props = this._pendingProps || this.props;
 
+  // update the root
+  this.parentState[this.path] = this.state;
+
   // reset.
   this.instance._pendingState = false;
   this._pendingProps = false;
@@ -221,6 +227,7 @@ ComponentRenderer.prototype.remove = function(){
     this.state,
     this.props,
   ]);
+  delete this.parentState[this.path];
   this.children = {};
   this.el = null;
 };
@@ -302,7 +309,7 @@ ComponentRenderer.prototype.toElement = function(node){
   }
 
   // otherwise, it's a component node.
-  var child = new ComponentRenderer(node.component, node.props);
+  var child = new ComponentRenderer(node.component, node.props, this.path + '.' + path, this.parentState);
   this.children[path] = child;
 
   // return el for components that have a root node that's another component.

--- a/lib/renderer/diff.js
+++ b/lib/renderer/diff.js
@@ -141,7 +141,7 @@ exports.diffComponent = function(previous, current, el){
   var child = this.children[path];
   var hasSameElement = child.el === this.el;
   child.setProps(current.props);
-  child.forceUpdate();
+  child.update();
 
   // if this child component the root node of another component
   // we should update the elements to match for future diffs

--- a/lib/renderer/mount.js
+++ b/lib/renderer/mount.js
@@ -19,11 +19,26 @@ module.exports = Mount;
  *
  * @param {Component} Component
  * @param {Object} props
+ * @param {Object} optState
  */
 
-function Mount(Component, props) {
-  this.rendered = new ComponentRenderer(Component, props);
+function Mount(Component, props, optState) {
+  this.state = optState || {};
+  this.rendered = new ComponentRenderer(Component, props, 'root', this.state);
 }
+
+/**
+ * Serialize the current state.
+ *
+ * @return {String}
+ */
+
+Mount.prototype.serialize = function() {
+  return JSON.stringify({
+    state: this.state,
+    props: this.rendered.props
+  });
+};
 
 /**
  * Add this mount to the DOM.

--- a/test/component/index.js
+++ b/test/component/index.js
@@ -13,6 +13,14 @@ describe('component', function(){
     assert.equal(el.innerHTML, '<span>Hello World</span>');
   });
 
+  it('should create a component with just a render function', function () {
+    var Page = component(function(dom, state, props){
+      return dom('span', null, [props.name]);
+    });
+    Page.render(el, { name: 'Link' });
+    assert.equal(el.innerHTML, '<span>Link</span>');
+  });
+
   it('should bind `this` to any method', function(done){
     var Page = component({
       hack: function(){

--- a/test/component/index.js
+++ b/test/component/index.js
@@ -223,4 +223,70 @@ describe('component', function(){
     assert.equal(el.innerHTML, '<span name="Bob">foo</span>');
   });
 
+  it('should store the state in a top-level object', function () {
+    var ComponentA = component({
+      afterMount: function(){
+        this.setState({ 'mounted': true });
+      },
+      render: function(n, state, props){
+        return n('span', { name: props.name }, [props.text]);
+      }
+    });
+    var ComponentB = component({
+      render: function(n, state, props){
+        return ComponentA({ text: 'foo', name: props.name });
+      }
+    });
+    var mount = ComponentB.render(el, { name: 'Bob' });
+    mount.forceUpdate();
+    assert.equal(mount.serialize(), '{"state":{"root":{},"root.0":{"mounted":true}},"props":{"name":"Bob"}}');
+  });
+
+  it('should remove state when a component is removed from the tree', function () {
+    var i = 0;
+    var ComponentA = component({
+      afterMount: function(){
+        this.setState({ 'mounted': true });
+      },
+      render: function(n, state, props){
+        return n('span', { name: props.name }, [props.text]);
+      }
+    });
+    var ComponentB = component({
+      render: function(n, state, props){
+        if (i === 0) {
+          return ComponentA({ text: 'foo', name: props.name });
+        } else {
+          return n();
+        }
+      }
+    });
+    var mount = ComponentB.render(el, { name: 'Bob' });
+    i = 1;
+    mount.forceUpdate();
+    assert.equal(mount.serialize(), '{"state":{"root":{}},"props":{"name":"Bob"}}');
+  });
+
+  it.only('should render in the same state', function () {
+    var i = 0;
+    var ComponentA = component({
+      afterMount: function(){
+        this.setState({ 'mounted': true });
+      },
+      render: function(n, state, props){
+        return n('span', { name: props.name }, [props.text]);
+      }
+    });
+    var ComponentB = component({
+      render: function(n, state, props){
+        if (i === 0) {
+          return ComponentA({ text: 'foo', name: props.name });
+        } else {
+          return n();
+        }
+      }
+    });
+    ComponentB.render(el, { name: 'Bob' }, { 'root': { open: true } });
+  });
+
 });


### PR DESCRIPTION
@lancejpollard 

This is what I was talking to you about today. The `Scene` can store the state for all the components in it's graph so they're not actually stored on the component itself:

```json
{
  "root": { "someKey": "value" },
  "root.0": { "open": true }
}
```

This means we can serialize a scene in it's current state (of all the components in the tree) with the props and the state separate. It's not working exactly right yet, this was more just a test. The state on the scene could be an immutable object so updating the state in a component is just updating the cursor.

Here's how it could look using `immstruct` in the `scene`:

```js
this.structure = immstruct({
  props: {},
  state: {}
});

this.structure.on('next-animation-frame', this.update);
```

Then we just update the cursors and the structure would swap. 