### PR TITLE
Fixed drag and drop test event, drag and drop 'flickers'

### DIFF
--- a/test/events/index.html
+++ b/test/events/index.html
@@ -247,26 +247,19 @@
     var Draggable = component(function(props, state){
       var self = this;
       function start(event) {
+        event.dataTransfer.setData('text', 'asdasd');
         self.setState({ active: true });
       }
       function end(event) {
         self.setState({ active: false });
       }
-      function enter(event) {
-        console.log('draggable', 'enter', event.target);
-      }
-      function leave(event) {
-        console.log('draggable', 'leave', event.target);
-      }
       var attrs = {
-        class: {
+        classes: {
           'active': state.active
         },
         draggable: true,
         onDragStart: start,
-        onDragEnd: end,
-        onDragEnter: enter,
-        onDragLeave: leave
+        onDragEnd: end
       };
       return dom('div.box', attrs, [
         'Drag Me'
@@ -277,19 +270,32 @@
       var self = this;
       function over(event) {
         event.preventDefault();
-        console.log('droppable', 'over', event.target);
+        //console.log('droppable', 'over', event.target);
       }
       function drop(event) {
+        event.preventDefault()
         console.log('droppable', 'drop', event.target);
+        self.setState({ dropped: true, active: false });
+      }
+      function enter(event) {
+        event.preventDefault()
+        console.log('draggable', 'enter', event.target);
+        self.setState({ active: true });
+      }
+      function leave(event) {
+        console.log('draggable', 'leave', event.target);
+        self.setState({ active: false });
       }
       var attrs = {
         classes: {
           'active': state.active
         },
         onDragOver: over,
-        onDrop: drop
+        onDrop: drop,
+        onDragEnter: enter,
+        onDragLeave: leave
       };
-      return dom('div.box', null, [
+      return dom('div.box', attrs, [
         state.dropped ? 'Dropped' : 'Drop Here'
       ]);
     });


### PR DESCRIPTION
I noticed that the drag and drop example wasn't wired up.

I was attempting to build my own drag and drop component and noticed that while the drag action is 'over' the drop destination the action flickers on mouse move. If dropped immediately after a mouse move the drop event doesn't fire. This also happens for this test event code.

I imagine using setState is recreating something that takes time and needs to complete before the html5 drag and drop detects it as a valid target again, however it's happening on mouse move. I also noticed that the 'over' event is firing for each mouse move event, which seems normal.

Any ideas? The flickering makes drag and drop fail randomly.