### PR TITLE
Update component#render() to throw if container is empty

### DIFF
--- a/lib/component/statics.js
+++ b/lib/component/statics.js
@@ -6,6 +6,7 @@
 var renderString = require('../renderer/string');
 var Entity = require('../entity');
 var Scene = require('../scene');
+var isDom = require('is-dom');
 
 /**
  * Browser dependencies.
@@ -65,6 +66,7 @@ exports.channel = function(name){
 
 exports.render = function(container, props){
   if (!HTMLRenderer) throw new Error('You can only render a DOM tree in the browser. Use renderString instead.');
+  if (!isDom(container)) throw new Error(container + ' is not a valid render target.');
   var renderer = new HTMLRenderer(container);
   var entity = new Entity(this, props);
   var scene = new Scene(renderer, entity);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "component-emitter": "^1.1.3",
     "extend": "^2.0.0",
     "get-uid": "^1.0.1",
+    "is-dom": "^1.0.5",
     "object-path": "^0.8.1",
     "per-frame": "^3.0.0",
     "raf-loop": "^1.0.1",


### PR DESCRIPTION
Checks if the target container is a valid DOM node. Gives a more human-friendly message than the current error which is just a 7-layer deep stack trace. Thanks!