### PR TITLE
not checking for equality, all calls to set should be respected

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -54,7 +54,6 @@ Application.prototype.option = function (name, val) {
  */
 
 Application.prototype.set = function (name, data) {
-  if (this.sources[name] === data) return
   this.sources[name] = data
   this.emit('source', name, data)
   return this


### PR DESCRIPTION
This allows data-sources that are "singletons" or otherwise some sort of container/wrapper object to be a data-source.

/cc @anthonyshort 